### PR TITLE
support string transformations on generated routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ touch app/views/pages/about.html.erb
 
 And create whatever content you want!
 
+If you'd like to modify the routes that Pages generates, you can alter the
+page parameter by passing an options hash containing a block. This is
+particularly useful for creating SEO-friendly routes:
+
+```ruby
+page :press_kit, :transform => { |page| page.dasherize }
+```
+
+would expand to:
+
+```ruby
+get '/press-kit' => 'pages#press_kit', :as => :press_kit
+```
+
 ## Authors ##
 
 [Brian Cardarella](http://twitter.com/bcardarella)

--- a/lib/pages/routes.rb
+++ b/lib/pages/routes.rb
@@ -1,12 +1,15 @@
 module ActionDispatch::Routing
   class Mapper
-    def page(_page)
-      get "/#{_page}" => "pages##{_page}", :as => _page
+    def page(_page, options={})
+      _route = options[:transform].call(_page.to_s) if options[:transform]
+      _route ||= _page
+      get "/#{_route}" => "pages##{_page}", :as => _page
     end
 
     def pages(*_pages)
+      options = _pages.extract_options!
       _pages.each do |_page|
-        page(_page)
+        page(_page, options)
       end
     end
   end

--- a/spec/dummy/app/views/pages/press_kit.html.erb
+++ b/spec/dummy/app/views/pages/press_kit.html.erb
@@ -1,0 +1,1 @@
+Press Kit Page

--- a/spec/dummy/app/views/pages/user_agreement.html.erb
+++ b/spec/dummy/app/views/pages/user_agreement.html.erb
@@ -1,0 +1,1 @@
+User Agreement Page

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   page :about
   pages :team, :contact
+  page :press_kit, :transform => lambda { |r| r.dasherize }
+  pages :press_kit, :user_agreement, :transform => lambda { |r| r.dasherize }
 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature 'Pages' do
   scenario 'loads the about page' do
-    visit'/about'
+    visit '/about'
     page.should have_content 'About Page'
   end
 
@@ -11,5 +11,17 @@ feature 'Pages' do
     page.should have_content 'Contact Page'
     visit '/team'
     page.should have_content 'Team Page'
+  end
+
+  scenario 'loads the press kit page' do
+    visit '/press-kit'
+    page.should have_content 'Press Kit Page'
+  end
+
+  scenario 'loads the press kit page' do
+    visit '/press-kit'
+    page.should have_content 'Press Kit Page'
+    visit '/user-agreement'
+    page.should have_content 'User Agreement Page'
   end
 end


### PR DESCRIPTION
Great gem! It works really well for single word routes. I wanted to use it to create multi-word routes and have a preference towards hyphens in URLs. Prior to this change, multi-word routes worked as follows:

``` ruby
page :press_kit
```

would generate:

``` ruby
get '/press_kit' => 'pages#press_kit', :as => :press_kit
```

I've added an options hash that supports passing a block to transform the route:

``` ruby
page 'press_kit', :transform => { |page| page.dasherize }
```

This modifies the route, but leave the rest as before:

``` ruby
get '/press-kit' => 'pages#press_kit', :as => :press_kit
```
