### PR TITLE
Updating the tests to use the newer rspec expectation syntax

### DIFF
--- a/spec/generators/pages/setup_generator_spec.rb
+++ b/spec/generators/pages/setup_generator_spec.rb
@@ -12,6 +12,6 @@ describe Pages::SetupGenerator do
   end
 
   it 'creates app/views/pages' do
-    Dir.exist?(File.expand_path('app/views/pages', destination_root)).should be_true
+    expect(Dir.exist?(File.expand_path('app/views/pages', destination_root))).to be true
   end
 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -3,40 +3,40 @@ require 'spec_helper'
 feature 'Pages' do
   scenario 'loads the About Page' do
     visit '/about'
-    page.should have_content 'About Page'
+    expect(page).to have_content 'About Page'
   end
 
   scenario 'loads the Contact Page then loads the Team Page' do
     visit '/contact'
-    page.should have_content 'Contact Page'
+    expect(page).to have_content 'Contact Page'
     visit '/team'
-    page.should have_content 'Team Page'
+    expect(page).to have_content 'Team Page'
   end
 
   scenario 'loads the Press Kit Page' do
     visit '/press-kit'
-    page.should have_content 'Press Kit Page'
+    expect(page).to have_content 'Press Kit Page'
   end
 
   scenario 'loads the Record Deal Page, then loads the User Agreement Page' do
     visit '/record-deal'
-    page.should have_content 'Record Deal Page'
+    expect(page).to have_content 'Record Deal Page'
     visit '/user-agreement'
-    page.should have_content 'User Agreement Page'
+    expect(page).to have_content 'User Agreement Page'
   end
 
   scenario 'allows namespacing of pages' do
     visit '/work/client'
-    page.should have_content 'Client'
+    expect(page).to have_content 'Client'
   end
 
   scenario 'allows plural namespacing of pages' do
     visit '/jobs/new_hire'
-    page.should have_content 'New Hire'
+    expect(page).to have_content 'New Hire'
   end
 
   scenario 'can override :as' do
     visit one_two_three_path
-    page.should have_content '123 Page'
+    expect(page).to have_content '123 Page'
   end
 end


### PR DESCRIPTION
I used the gem with rspec-rails 3.0.0 and the tests failed so I updated from the should syntax to the expect syntax in the tests and now they pass. 

Hopefully this helps, let me know if there are any issues with it and thank you so much from creating and maintaining this project.
